### PR TITLE
Forward the no_createrepo argument in add_rpm and delete_rpm to be consistent

### DIFF
--- a/repo_manager.spec
+++ b/repo_manager.spec
@@ -53,9 +53,8 @@ install repo_manager.cfg.sample %{buildroot}/%{_sysconfdir}/%{name}/
 %{_bindir}/%{name}
 
 %changelog
-- Drop the sed removing the sheband in repo_manager/__init__.py, fixed upstream
-
 * Thu Jul 17 2014 Pierre-Yves Chibon <pingou@pingoured.fr> - 0.1.0-3
+- Drop the sed removing the sheband in repo_manager/__init__.py, fixed upstream
 - Drop shebang in repo_manager/__init__.py
 
 * Wed Jul 02 2014 Pierre-Yves Chibon <pingou@pingoured.fr> - 0.1.0-2

--- a/repo_manager.spec
+++ b/repo_manager.spec
@@ -53,8 +53,9 @@ install repo_manager.cfg.sample %{buildroot}/%{_sysconfdir}/%{name}/
 %{_bindir}/%{name}
 
 %changelog
-* Thu Jul 17 2014 Pierre-Yves Chibon <pingou@pingoured.fr> - 0.1.0-3
 - Drop the sed removing the sheband in repo_manager/__init__.py, fixed upstream
+
+* Thu Jul 17 2014 Pierre-Yves Chibon <pingou@pingoured.fr> - 0.1.0-3
 - Drop shebang in repo_manager/__init__.py
 
 * Wed Jul 02 2014 Pierre-Yves Chibon <pingou@pingoured.fr> - 0.1.0-2

--- a/repo_manager/repo_manager.py
+++ b/repo_manager/repo_manager.py
@@ -316,13 +316,6 @@ def replace_rpm(rpm, folder, no_createrepo=False, createrepo_cmd=None,
         createrepo_cmd=createrepo_cmd,
         message=message)
 
-    delete_rpm(
-        rpm, folder_from,
-        no_createrepo=no_createrepo,
-        createrepo_cmd=createrepo_cmd,
-        message=message)
-        
-
 def ugrade_rpm(rpm, folder_from, folder_to,
                no_createrepo=False, createrepo_cmd=None, message=None):
     ''' Upgrade/copy the specified RPM from one repo into another one.

--- a/repo_manager/repo_manager.py
+++ b/repo_manager/repo_manager.py
@@ -304,13 +304,24 @@ def replace_rpm(rpm, folder, no_createrepo=False, createrepo_cmd=None,
     if '/' in rpm:
         rpmfile = rpm.rsplit('/', 1)[1]
 
-    delete_rpm(rpmfile, folder, message=message)
-    if not no_createrepo:
-        run_createrepo(folder, createrepo_cmd=createrepo_cmd)
-    add_rpm(rpm, folder, message=message)
-    if not no_createrepo:
-        run_createrepo(folder, createrepo_cmd=createrepo_cmd)
+    delete_rpm(
+        rpm, folder_from,
+        no_createrepo=no_createrepo,
+        createrepo_cmd=createrepo_cmd,
+        message=message)
+        
+    add_rpm(
+        path, folder_to,
+        no_createrepo=no_createrepo,
+        createrepo_cmd=createrepo_cmd,
+        message=message)
 
+    delete_rpm(
+        rpm, folder_from,
+        no_createrepo=no_createrepo,
+        createrepo_cmd=createrepo_cmd,
+        message=message)
+        
 
 def ugrade_rpm(rpm, folder_from, folder_to,
                no_createrepo=False, createrepo_cmd=None, message=None):


### PR DESCRIPTION
I am working on a repo server that tracks the number of times an rpm has been downloaded to better understand the usefulness of a version on a private repo. Decided to share some thoughts. Feel free to ignore.
